### PR TITLE
feat: add music sync endpoint to resend current playing music

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,6 +141,7 @@ var route = map[string]func(ctx *Context){
 	"/music/skip/vote":      voteSkip,
 	"/music/searchsonglist": searchList,
 	"/music/playmode":       playMode,
+	"/music/sync":           getCurrentMusic,
 	"/house/houseuser":      houseuser,
 }
 

--- a/music.go
+++ b/music.go
@@ -206,3 +206,16 @@ func playMode(c *Context) {
 		}
 	})
 }
+
+func getCurrentMusic(c *Context) {
+	c.WithHouse(func(h *House) {
+		if h.Current.id != "" {
+			// 发送播放单曲
+			m := music.GetMusic(h.Current.source, h.Current.id, false)
+			r := merge(m, gin.H{
+				"pushTime": h.PushTime,
+			})
+			c.conn.Send(r)
+		}
+	})
+}


### PR DESCRIPTION
- Add /music/sync route to allow frontend to request current music state
- Implement getCurrentMusic function to resend currently playing music with pushTime
- Enables frontend to manually sync music playback state when needed

closed #3