### PR TITLE
fix: 统一User字段类型为auth.User

### DIFF
--- a/music.go
+++ b/music.go
@@ -118,12 +118,12 @@ func doPickMusic(house *House, id, name, source string, user auth.User) PickMusi
 // HTTP version of pickMusic handler
 func pickMusicHTTP(w http.ResponseWriter, r *http.Request) {
 	var request struct {
-		HouseID  string `json:"houseId"`
-		Password string `json:"housePwd"`
-		User     string `json:"user"`
-		ID       string `json:"id"`
-		Name     string `json:"name"`
-		Source   string `json:"source"`
+		HouseID  string    `json:"houseId"`
+		Password string    `json:"housePwd"`
+		User     auth.User `json:"user"`
+		ID       string    `json:"id"`
+		Name     string    `json:"name"`
+		Source   string    `json:"source"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
@@ -141,7 +141,7 @@ func pickMusicHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result := doPickMusic(house, request.ID, request.Name, request.Source, auth.User{Name: request.User})
+	result := doPickMusic(house, request.ID, request.Name, request.Source, request.User)
 
 	if result.Success {
 		writeJSON(w, http.StatusOK, base.H{


### PR DESCRIPTION
将pickMusicHTTP请求结构体中的User字段从string类型改为auth.User类型， 与代码库中其他地方保持类型一致性，并简化调用逻辑。