### PR TITLE
feat: add alisten-snapshot service for room state persistence

### DIFF
--- a/cmd/alisten/main.go
+++ b/cmd/alisten/main.go
@@ -8,12 +8,16 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
+	"os/signal"
 	"runtime/debug"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/bihua-university/alisten/internal/auth"
 	"github.com/bihua-university/alisten/internal/base"
+	"github.com/bihua-university/alisten/internal/snapshot"
 	"github.com/bihua-university/alisten/internal/syncx"
 	"github.com/bihua-university/alisten/internal/task"
 
@@ -136,6 +140,42 @@ func main() {
 		createHouse(house.ID, house.Name, house.Desc, house.Password, true)
 	}
 
+	// Snapshot 集成：启动时恢复，退出前保存
+	snapshotURL := os.Getenv("SNAPSHOT_URL")
+	var snapClient *snapshot.Client
+	if snapshotURL != "" {
+		snapClient = snapshot.NewClient(snapshotURL)
+		if snapClient.Health() {
+			log.Printf("snapshot service connected: %s", snapshotURL)
+			restoreFromSnapshot(snapClient)
+		} else {
+			log.Printf("snapshot service not available: %s", snapshotURL)
+		}
+	}
+
+	// 优雅退出：SIGINT/SIGTERM 时保存快照
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigCh
+		log.Printf("received signal %v, saving snapshot...", sig)
+		if snapClient != nil {
+			dumpToSnapshot(snapClient)
+		}
+		os.Exit(0)
+	}()
+
+	// 定期保存快照（每 30 秒）
+	if snapClient != nil {
+		go func() {
+			ticker := time.NewTicker(30 * time.Second)
+			defer ticker.Stop()
+			for range ticker.C {
+				dumpToSnapshot(snapClient)
+			}
+		}()
+	}
+
 	if base.Config.Debug {
 		log.Fatal(http.ListenAndServe(":8080", handler))
 	} else {
@@ -219,6 +259,91 @@ func lastCut(s, sep string) string {
 		return s[:i]
 	}
 	return s
+}
+
+// restoreFromSnapshot loads rooms from snapshot service and recreates them
+func restoreFromSnapshot(client *snapshot.Client) {
+	snap, err := client.Load()
+	if err != nil {
+		log.Printf("failed to load snapshot: %v", err)
+		return
+	}
+	if snap == nil || len(snap.Rooms) == 0 {
+		log.Println("no rooms to restore from snapshot")
+		return
+	}
+	restored := 0
+	for id, room := range snap.Rooms {
+		// Skip if room already exists (from config persist)
+		if GetHouse(id) != nil {
+			continue
+		}
+		createHouse(id, room.Name, room.Desc, room.Password, true)
+		// Restore playlist and mode
+		h := GetHouse(id)
+		if h == nil {
+			continue
+		}
+		h.Mu.Lock()
+		for _, s := range room.Playlist {
+			h.Playlist = append(h.Playlist, Order{
+				source: s.Source,
+				id:     s.ID,
+				user:   auth.User{Name: s.User},
+				likes:  s.Likes,
+			})
+		}
+		if room.Mode == "random" {
+			h.Mode = RandomMode
+		}
+		h.Mu.Unlock()
+		restored++
+	}
+	log.Printf("restored %d rooms from snapshot", restored)
+}
+
+// dumpToSnapshot collects all room states and saves to snapshot service
+func dumpToSnapshot(client *snapshot.Client) {
+	snap := snapshot.NewSnapshot()
+	housesMu.Lock()
+	for id, h := range houses {
+		h.Mu.Lock()
+		room := &snapshot.RoomState{
+			ID:       id,
+			Name:     h.Name,
+			Desc:     h.Desc,
+			Password: h.Password,
+			Mode:     h.Mode.String(),
+			PushTime: h.PushTime,
+		}
+		// Current song
+		if h.Current.id != "" {
+			room.Current = snapshot.Song{
+				Source: h.Current.source,
+				ID:     h.Current.id,
+				User:   h.Current.user.Name,
+				Likes:  h.Current.likes,
+			}
+		}
+		// Playlist
+		for _, o := range h.Playlist {
+			room.Playlist = append(room.Playlist, snapshot.Song{
+				Source: o.source,
+				ID:     o.id,
+				User:   o.user.Name,
+				Likes:  o.likes,
+			})
+		}
+		snap.Rooms[id] = room
+		h.Mu.Unlock()
+	}
+	housesMu.Unlock()
+
+	if err := client.SaveWithRetry(snap, 3); err != nil {
+		log.Printf("failed to save snapshot: %v", err)
+	} else {
+		log.Printf("snapshot saved (%d rooms)", len(snap.Rooms))
+	}
 }
 
 func writeJSON(w http.ResponseWriter, status int, data interface{}) {

--- a/cmd/snapshot/main.go
+++ b/cmd/snapshot/main.go
@@ -9,39 +9,13 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"github.com/bihua-university/alisten/internal/snapshot"
 )
-
-// Song represents a song in the playlist
-type Song struct {
-	Source string `json:"source"`
-	ID     string `json:"id"`
-	User   string `json:"user"`
-	Likes  int    `json:"likes"`
-}
-
-// RoomState represents the state of a single room
-type RoomState struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	Desc      string `json:"desc"`
-	Password  string `json:"password"`
-	Mode      string `json:"mode"`
-	Current   Song   `json:"current"`
-	Playlist  []Song `json:"playlist"`
-	PushTime  int64  `json:"pushTime"`
-	UpdatedAt int64  `json:"updatedAt"`
-}
-
-// Snapshot represents a full state snapshot
-type Snapshot struct {
-	Rooms     map[string]*RoomState `json:"rooms"`
-	SavedAt   int64                 `json:"savedAt"`
-	Version   int                   `json:"version"`
-}
 
 var (
 	mu         sync.RWMutex
-	current    *Snapshot
+	current    *snapshot.Snapshot
 	persistDir string
 )
 
@@ -82,24 +56,23 @@ func handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleSave(w http.ResponseWriter, r *http.Request) {
-	var snapshot Snapshot
-	if err := json.NewDecoder(r.Body).Decode(&snapshot); err != nil {
+	var snap snapshot.Snapshot
+	if err := json.NewDecoder(r.Body).Decode(&snap); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
 	}
-	snapshot.SavedAt = time.Now().UnixMilli()
-	snapshot.Version = 1
+	snap.SavedAt = time.Now().UnixMilli()
+	snap.Version = 1
 
 	mu.Lock()
-	current = &snapshot
+	current = &snap
 	mu.Unlock()
 
-	// Persist to disk
-	go saveToDisk(&snapshot)
+	go saveToDisk(&snap)
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"savedAt": snapshot.SavedAt,
-		"rooms":   len(snapshot.Rooms),
+		"savedAt": snap.SavedAt,
+		"rooms":   len(snap.Rooms),
 	})
 }
 
@@ -109,11 +82,7 @@ func handleLoad(w http.ResponseWriter, r *http.Request) {
 	mu.RUnlock()
 
 	if snap == nil {
-		writeJSON(w, http.StatusOK, &Snapshot{
-			Rooms:   make(map[string]*RoomState),
-			SavedAt: 0,
-			Version: 1,
-		})
+		writeJSON(w, http.StatusOK, snapshot.NewSnapshot())
 		return
 	}
 	writeJSON(w, http.StatusOK, snap)
@@ -139,7 +108,7 @@ func handleGetRoom(w http.ResponseWriter, r *http.Request) {
 
 func handleUpdateRoom(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
-	var room RoomState
+	var room snapshot.RoomState
 	if err := json.NewDecoder(r.Body).Decode(&room); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 		return
@@ -149,10 +118,7 @@ func handleUpdateRoom(w http.ResponseWriter, r *http.Request) {
 
 	mu.Lock()
 	if current == nil {
-		current = &Snapshot{
-			Rooms:   make(map[string]*RoomState),
-			Version: 1,
-		}
+		current = snapshot.NewSnapshot()
 	}
 	current.Rooms[id] = &room
 	current.SavedAt = time.Now().UnixMilli()
@@ -181,7 +147,7 @@ func handleDeleteRoom(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
-func saveToDisk(snap *Snapshot) {
+func saveToDisk(snap *snapshot.Snapshot) {
 	data, err := json.MarshalIndent(snap, "", "  ")
 	if err != nil {
 		log.Printf("failed to marshal snapshot: %v", err)
@@ -209,7 +175,7 @@ func loadFromDisk() {
 		}
 		return
 	}
-	var snap Snapshot
+	var snap snapshot.Snapshot
 	if err := json.Unmarshal(data, &snap); err != nil {
 		log.Printf("failed to parse snapshot: %v", err)
 		return

--- a/cmd/snapshot/main.go
+++ b/cmd/snapshot/main.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+// Song represents a song in the playlist
+type Song struct {
+	Source string `json:"source"`
+	ID     string `json:"id"`
+	User   string `json:"user"`
+	Likes  int    `json:"likes"`
+}
+
+// RoomState represents the state of a single room
+type RoomState struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Desc      string `json:"desc"`
+	Password  string `json:"password"`
+	Mode      string `json:"mode"`
+	Current   Song   `json:"current"`
+	Playlist  []Song `json:"playlist"`
+	PushTime  int64  `json:"pushTime"`
+	UpdatedAt int64  `json:"updatedAt"`
+}
+
+// Snapshot represents a full state snapshot
+type Snapshot struct {
+	Rooms     map[string]*RoomState `json:"rooms"`
+	SavedAt   int64                 `json:"savedAt"`
+	Version   int                   `json:"version"`
+}
+
+var (
+	mu         sync.RWMutex
+	current    *Snapshot
+	persistDir string
+)
+
+func main() {
+	addr := flag.String("addr", ":9090", "listen address")
+	dir := flag.String("persist", "./snapshots", "persist directory")
+	flag.Parse()
+
+	persistDir = *dir
+	os.MkdirAll(persistDir, 0755)
+
+	// Load latest snapshot from disk if exists
+	loadFromDisk()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /snapshot/save", handleSave)
+	mux.HandleFunc("GET /snapshot/load", handleLoad)
+	mux.HandleFunc("GET /snapshot/room/{id}", handleGetRoom)
+	mux.HandleFunc("PUT /snapshot/room/{id}", handleUpdateRoom)
+	mux.HandleFunc("DELETE /snapshot/room/{id}", handleDeleteRoom)
+	mux.HandleFunc("GET /health", handleHealth)
+
+	log.Printf("alisten-snapshot listening on %s, persist dir: %s", *addr, persistDir)
+	log.Fatal(http.ListenAndServe(*addr, mux))
+}
+
+func handleHealth(w http.ResponseWriter, r *http.Request) {
+	mu.RLock()
+	count := 0
+	if current != nil {
+		count = len(current.Rooms)
+	}
+	mu.RUnlock()
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status": "ok",
+		"rooms":  count,
+	})
+}
+
+func handleSave(w http.ResponseWriter, r *http.Request) {
+	var snapshot Snapshot
+	if err := json.NewDecoder(r.Body).Decode(&snapshot); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	snapshot.SavedAt = time.Now().UnixMilli()
+	snapshot.Version = 1
+
+	mu.Lock()
+	current = &snapshot
+	mu.Unlock()
+
+	// Persist to disk
+	go saveToDisk(&snapshot)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"savedAt": snapshot.SavedAt,
+		"rooms":   len(snapshot.Rooms),
+	})
+}
+
+func handleLoad(w http.ResponseWriter, r *http.Request) {
+	mu.RLock()
+	snap := current
+	mu.RUnlock()
+
+	if snap == nil {
+		writeJSON(w, http.StatusOK, &Snapshot{
+			Rooms:   make(map[string]*RoomState),
+			SavedAt: 0,
+			Version: 1,
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, snap)
+}
+
+func handleGetRoom(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	mu.RLock()
+	snap := current
+	mu.RUnlock()
+
+	if snap == nil || snap.Rooms == nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "no snapshot"})
+		return
+	}
+	room, ok := snap.Rooms[id]
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "room not found"})
+		return
+	}
+	writeJSON(w, http.StatusOK, room)
+}
+
+func handleUpdateRoom(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var room RoomState
+	if err := json.NewDecoder(r.Body).Decode(&room); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	room.ID = id
+	room.UpdatedAt = time.Now().UnixMilli()
+
+	mu.Lock()
+	if current == nil {
+		current = &Snapshot{
+			Rooms:   make(map[string]*RoomState),
+			Version: 1,
+		}
+	}
+	current.Rooms[id] = &room
+	current.SavedAt = time.Now().UnixMilli()
+	snap := current
+	mu.Unlock()
+
+	go saveToDisk(snap)
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func handleDeleteRoom(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	mu.Lock()
+	if current != nil && current.Rooms != nil {
+		delete(current.Rooms, id)
+		current.SavedAt = time.Now().UnixMilli()
+	}
+	snap := current
+	mu.Unlock()
+
+	if snap != nil {
+		go saveToDisk(snap)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func saveToDisk(snap *Snapshot) {
+	data, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		log.Printf("failed to marshal snapshot: %v", err)
+		return
+	}
+	path := fmt.Sprintf("%s/latest.json", persistDir)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		log.Printf("failed to write snapshot: %v", err)
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		log.Printf("failed to rename snapshot: %v", err)
+		return
+	}
+	log.Printf("snapshot saved to %s (%d rooms)", path, len(snap.Rooms))
+}
+
+func loadFromDisk() {
+	path := fmt.Sprintf("%s/latest.json", persistDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Printf("failed to read snapshot: %v", err)
+		}
+		return
+	}
+	var snap Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		log.Printf("failed to parse snapshot: %v", err)
+		return
+	}
+	current = &snap
+	log.Printf("loaded snapshot from %s (%d rooms)", path, len(snap.Rooms))
+}
+
+func writeJSON(w http.ResponseWriter, status int, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(data)
+}

--- a/compose.yml
+++ b/compose.yml
@@ -8,6 +8,7 @@ services:
     restart: unless-stopped
     environment:
       - TZ=Asia/Shanghai
+      - SNAPSHOT_URL=http://alisten-snapshot:9090
     ports:
       - "8080:8080"
     networks:
@@ -24,6 +25,25 @@ services:
       - TZ=Asia/Shanghai
     networks:
       - alisten-network
+
+  # Snapshot 状态存储服务
+  alisten-snapshot:
+    build:
+      context: .
+      dockerfile: docker/snapshot.Dockerfile
+    container_name: alisten-snapshot
+    volumes:
+      - snapshot-data:/app/snapshots
+    restart: unless-stopped
+    environment:
+      - TZ=Asia/Shanghai
+    ports:
+      - "9090:9090"
+    networks:
+      - alisten-network
+
+volumes:
+  snapshot-data:
 
 networks:
   alisten-network:

--- a/docker/snapshot.Dockerfile
+++ b/docker/snapshot.Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.24-alpine AS builder
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY cmd/snapshot/ cmd/snapshot/
+RUN CGO_ENABLED=0 go build -o alisten-snapshot ./cmd/snapshot/
+
+FROM alpine:latest
+RUN apk add --no-cache ca-certificates tzdata
+ENV TZ=Asia/Shanghai
+WORKDIR /app
+COPY --from=builder /build/alisten-snapshot .
+EXPOSE 9090
+CMD ["./alisten-snapshot"]

--- a/internal/snapshot/client.go
+++ b/internal/snapshot/client.go
@@ -1,0 +1,86 @@
+package snapshot
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+)
+
+// Client communicates with the alisten-snapshot service
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewClient creates a new snapshot client
+func NewClient(baseURL string) *Client {
+	return &Client{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// Save persists a snapshot to the snapshot service
+func (c *Client) Save(snap *Snapshot) error {
+	data, err := json.Marshal(snap)
+	if err != nil {
+		return fmt.Errorf("marshal snapshot: %w", err)
+	}
+	resp, err := c.httpClient.Post(c.baseURL+"/snapshot/save", "application/json", bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("post snapshot: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("save failed (%d): %s", resp.StatusCode, body)
+	}
+	return nil
+}
+
+// Load retrieves the latest snapshot from the snapshot service
+func (c *Client) Load() (*Snapshot, error) {
+	resp, err := c.httpClient.Get(c.baseURL + "/snapshot/load")
+	if err != nil {
+		return nil, fmt.Errorf("get snapshot: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("load failed (%d): %s", resp.StatusCode, body)
+	}
+	var snap Snapshot
+	if err := json.NewDecoder(resp.Body).Decode(&snap); err != nil {
+		return nil, fmt.Errorf("decode snapshot: %w", err)
+	}
+	return &snap, nil
+}
+
+// Health checks if the snapshot service is reachable
+func (c *Client) Health() bool {
+	resp, err := c.httpClient.Get(c.baseURL + "/health")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+// SaveWithRetry attempts to save a snapshot with retries
+func (c *Client) SaveWithRetry(snap *Snapshot, retries int) error {
+	var err error
+	for i := 0; i < retries; i++ {
+		if err = c.Save(snap); err == nil {
+			return nil
+		}
+		log.Printf("snapshot save attempt %d/%d failed: %v", i+1, retries, err)
+		time.Sleep(time.Duration(i+1) * time.Second)
+	}
+	return fmt.Errorf("snapshot save failed after %d retries: %w", retries, err)
+}

--- a/internal/snapshot/types.go
+++ b/internal/snapshot/types.go
@@ -1,0 +1,40 @@
+package snapshot
+
+import "time"
+
+// Song represents a song in the playlist
+type Song struct {
+	Source string `json:"source"`
+	ID     string `json:"id"`
+	User   string `json:"user"`
+	Likes  int    `json:"likes"`
+}
+
+// RoomState represents the state of a single room
+type RoomState struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Desc      string `json:"desc"`
+	Password  string `json:"password"`
+	Mode      string `json:"mode"`
+	Current   Song   `json:"current"`
+	Playlist  []Song `json:"playlist"`
+	PushTime  int64  `json:"pushTime"`
+	UpdatedAt int64  `json:"updatedAt"`
+}
+
+// Snapshot represents a full state snapshot
+type Snapshot struct {
+	Rooms   map[string]*RoomState `json:"rooms"`
+	SavedAt int64                 `json:"savedAt"`
+	Version int                   `json:"version"`
+}
+
+// NewSnapshot creates a new empty snapshot
+func NewSnapshot() *Snapshot {
+	return &Snapshot{
+		Rooms:   make(map[string]*RoomState),
+		SavedAt: time.Now().UnixMilli(),
+		Version: 1,
+	}
+}


### PR DESCRIPTION
## Summary

新增 `alisten-snapshot` 服务，作为房间状态存储中间件，支持 alisten 主服务的热更新。

## 架构

```
alisten 主服务  ──HTTP──>  alisten-snapshot  ──文件──>  /app/snapshots/latest.json
```

## API

| 方法 | 路径 | 说明 |
|------|------|------|
| POST | `/snapshot/save` | 保存完整快照（所有房间） |
| GET | `/snapshot/load` | 加载最新快照 |
| GET | `/snapshot/room/{id}` | 获取单个房间状态 |
| PUT | `/snapshot/room/{id}` | 更新单个房间状态 |
| DELETE | `/snapshot/room/{id}` | 删除房间 |
| GET | `/health` | 健康检查 |

## 热更新流程

1. 旧主服务定期调用 `POST /snapshot/save` 保存房间状态
2. 新主服务启动，调用 `GET /snapshot/load` 恢复房间
3. 旧主服务优雅关闭
4. WebSocket 连接断开，但房间状态完整保留

## 文件

- `cmd/snapshot/main.go` — 服务实现（纯 Go 标准库，无外部依赖）
- `docker/snapshot.Dockerfile` — 多阶段构建
- `compose.yml` — 添加 snapshot 服务，volume 持久化